### PR TITLE
Fixed issue with render deployment port binding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/comments', commentRoutes);
 
-const PORT: number = parseInt(process.env.PORT as string, 10);
+const PORT = Number(process.env.PORT) || 3000;
 const MONGODB_URI: string = process.env.MONGODB_URI as string;
 
 // For CI/CD health check


### PR DESCRIPTION
I had to include a fallback for the port because the render deployment was breaking.

I found out the process.env.PORT is usually undefined in render's early startup phase despite PORT being defined in the environment variables leading to an error. Hence the change.